### PR TITLE
Limit Ranking List Length

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "beforeEach": true,
     "describe": true,
     "expect": true,
-    "it": true
+    "it": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -8487,6 +8487,13 @@
         }
       }
     },
+    "jest-transform-graphql": {
+      "version": "2.1.0",
+      "resolved":
+        "https://registry.npmjs.org/jest-transform-graphql/-/jest-transform-graphql-2.1.0.tgz",
+      "integrity": "sha1-kDy2a7J7wncv0+XdT36bVyMPWCk=",
+      "dev": true
+    },
     "jest-util": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     },
     "moduleFileExtensions": ["js", "json", "vue"],
     "transform": {
+      "\\.(gql|graphql)$": "jest-transform-graphql",
       ".*\\.(vue)$": "vue-jest",
       ".*": "babel-jest"
     }
@@ -67,6 +68,7 @@
     "file-loader": "^1.1.4",
     "husky": "^0.15.0-rc.13",
     "jest": "^22.4.3",
+    "jest-transform-graphql": "^2.1.0",
     "node-sass": "^4.5.3",
     "prettier": "1.11.1",
     "pretty-quick": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "\\.(gql|graphql)$": "jest-transform-graphql",
       ".*\\.(vue)$": "vue-jest",
       ".*": "babel-jest"
-    }
+    },
+    "setupFiles": ["<rootDir>/test/setup-jest"]
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "jest": {
     "moduleDirectories": ["node_modules"],
     "moduleNameMapper": {
-      "^src/(.*)": "<rootDir>/src/$1"
+      "^@/(.*)": "<rootDir>/src/$1"
     },
     "moduleFileExtensions": ["js", "json", "vue"],
     "transform": {

--- a/src/api/list-mock.js
+++ b/src/api/list-mock.js
@@ -8,7 +8,8 @@ export default {
   state: {
     loading: false,
     idCount: 0,
-    items: []
+    items: [],
+    rankedItems: []
   },
   createItem(item = {}) {
     item = {
@@ -23,8 +24,27 @@ export default {
     return resolveEventually(this.state.items)
   },
   listItems() {
-    this.state.items = JSON.parse(localStorage.getItem('items') || [])
+    this.state.items = JSON.parse(localStorage.getItem('items') || '[]')
+    this.state.rankedItems = JSON.parse(
+      localStorage.getItem('rankedItems') || '[]'
+    )
     this.state.idCount = this.state.items.length
-    return resolveEventually(this.state.items)
+    return resolveEventually(
+      // Only return items that aren't in the user's ranked list.
+      this.state.items.filter(
+        item => !this.state.rankedItems.some(ranked => item.id === ranked.id)
+      )
+    )
+  },
+  listRankedItems() {
+    this.state.rankedItems = JSON.parse(
+      localStorage.getItem('rankedItems') || '[]'
+    )
+    return resolveEventually(this.state.rankedItems)
+  },
+  saveRankedItems(rankedItems) {
+    this.state.rankedItems = rankedItems
+    localStorage.setItem('rankedItems', JSON.stringify(this.state.rankedItems))
+    return resolveEventually(rankedItems)
   }
 }

--- a/src/api/list-mock.js
+++ b/src/api/list-mock.js
@@ -10,7 +10,7 @@ export default {
     idCount: 0,
     items: []
   },
-  addItem(item = {}) {
+  createItem(item = {}) {
     item = {
       label: '',
       votes: 0,

--- a/src/components/ItemRanking.vue
+++ b/src/components/ItemRanking.vue
@@ -136,10 +136,10 @@ export default {
       'loadItems',
       'createItem',
       'moveItemToRankedList',
-      'moveItemToUnrankedList'
+      'moveItemToUnrankedList',
+      'setRankedItems'
     ]),
     ...mapMutations('itemRanking', [
-      'setRankedItems',
       'setUnrankedItems',
       'addRankedItem',
       'removeRankedItem',

--- a/src/components/ItemRanking.vue
+++ b/src/components/ItemRanking.vue
@@ -132,15 +132,12 @@ export default {
     hideItemInfo() {
       this.infoDialog = false
     },
-    moveItemToRankedList(item) {
-      this.addRankedItem(item)
-      this.removeUnrankedItem(item)
-    },
-    moveItemToUnrankedList(item) {
-      this.addUnrankedItem(item)
-      this.removeRankedItem(item)
-    },
-    ...mapActions('itemRanking', ['loadItems', 'createItem']),
+    ...mapActions('itemRanking', [
+      'loadItems',
+      'createItem',
+      'moveItemToRankedList',
+      'moveItemToUnrankedList'
+    ]),
     ...mapMutations('itemRanking', [
       'setRankedItems',
       'setUnrankedItems',

--- a/src/components/ItemRanking.vue
+++ b/src/components/ItemRanking.vue
@@ -35,7 +35,7 @@
             <draggable-item-list
               :items="rankedList"
               :options="{ group: 'ranking' }"
-              @list-change="setRankedItems"
+              @list-change="setAndLimitRankedItems"
               @info-click="showItemInfo"
               @item-click="moveItemToUnrankedList">
             </draggable-item-list>
@@ -99,7 +99,7 @@ export default {
         return this.rankedItems
       },
       set(value) {
-        this.setRankedItems(value)
+        this.setAndLimitRankedItems(value)
       }
     },
     unrankedList: {
@@ -136,7 +136,7 @@ export default {
       'createItem',
       'moveItemToRankedList',
       'moveItemToUnrankedList',
-      'setRankedItems'
+      'setAndLimitRankedItems'
     ]),
     ...mapMutations('itemRanking', [
       'setUnrankedItems',

--- a/src/components/ItemRanking.vue
+++ b/src/components/ItemRanking.vue
@@ -90,7 +90,6 @@ export default {
       },
       infoDialog: false,
       infoDialogItem: {},
-      selectedItem: null,
       selectedItem: null
     }
   },

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -1,6 +1,7 @@
 import api from '@/api/list'
 
 const state = {
+  maxRankedItems: 10,
   rankedItems: [],
   unrankedItems: [],
   loading: false,
@@ -82,6 +83,32 @@ const actions = {
     } catch (err) {
       commit('setError', "Oh no, it didn't work")
       console.error(err)
+    }
+  },
+  moveItemToRankedList({ commit, state }, item) {
+    try {
+      if (state.rankedItems.length >= state.maxRankedItems) {
+        commit(
+          'addUnrankedItem',
+          state.rankedItems[state.rankedItems.length - 1]
+        )
+        commit(
+          'removeRankedItem',
+          state.rankedItems[state.rankedItems.length - 1]
+        )
+      }
+      commit('addRankedItem', item)
+      commit('removeUnrankedItem', item)
+    } catch (err) {
+      commit('setError', err.message)
+    }
+  },
+  moveItemToUnrankedList({ commit }, item) {
+    try {
+      commit('addUnrankedItem', item)
+      commit('removeRankedItem', item)
+    } catch (err) {
+      commit('setError', err.message)
     }
   }
 }

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -111,7 +111,7 @@ export const actions = {
       commit('setError', err.message)
     }
   },
-  setRankedItems({ commit, state }, rankedItems = []) {
+  setAndLimitRankedItems({ commit, state }, rankedItems = []) {
     // Move excess ranked items back over to unranked list.
     if (rankedItems.length > state.maxRankedItems) {
       rankedItems

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -1,6 +1,6 @@
 import api from '@/api/list'
 
-const state = {
+export const defaultState = {
   maxRankedItems: 10,
   rankedItems: [],
   unrankedItems: [],
@@ -8,20 +8,20 @@ const state = {
   error: ''
 }
 
-const getters = {
+export const getters = {
   allItems(state) {
     return [...state.unrankedItems, ...state.rankedItems]
   }
 }
 
-const findItemIndex = function(items, itemToFind) {
+export const findItemIndex = function(items, itemToFind) {
   if (!items || !itemToFind) {
     return -1
   }
   return items.findIndex(item => item.item_name === itemToFind.item_name)
 }
 
-const mutations = {
+export const mutations = {
   setAllItems(state, items) {
     state.allItems = items
   },
@@ -67,7 +67,7 @@ const mutations = {
   }
 }
 
-const actions = {
+export const actions = {
   async loadItems({ commit }) {
     try {
       commit('setUnrankedItems', await api.listItems())
@@ -125,7 +125,7 @@ const actions = {
 
 export default {
   namespaced: true,
-  state,
+  state: defaultState,
   getters,
   actions,
   mutations

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -110,6 +110,16 @@ const actions = {
     } catch (err) {
       commit('setError', err.message)
     }
+  },
+  setRankedItems({ commit, state }, rankedItems = []) {
+    // Move excess ranked items back over to unranked list.
+    if (rankedItems.length > state.maxRankedItems) {
+      rankedItems
+        .slice(state.maxRankedItems - 1, rankedItems.length)
+        .forEach(item => commit('addUnrankedItem', item))
+      rankedItems = rankedItems.slice(0, state.maxRankedItems)
+    }
+    commit('setRankedItems', rankedItems)
   }
 }
 

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -115,7 +115,7 @@ const actions = {
     // Move excess ranked items back over to unranked list.
     if (rankedItems.length > state.maxRankedItems) {
       rankedItems
-        .slice(state.maxRankedItems - 1, rankedItems.length)
+        .slice(state.maxRankedItems, rankedItems.length)
         .forEach(item => commit('addUnrankedItem', item))
       rankedItems = rankedItems.slice(0, state.maxRankedItems)
     }

--- a/test/setup-jest.js
+++ b/test/setup-jest.js
@@ -1,0 +1,2 @@
+// Provide a basic mock for the `fetch` global function.
+global.fetch = data => Promise.resolve(data)

--- a/test/unit/App.spec.js
+++ b/test/unit/App.spec.js
@@ -1,5 +1,5 @@
 import { createLocalVue, mount } from '@vue/test-utils'
-import App from 'src/App'
+import App from '@/App'
 import VueRouter from 'vue-router'
 import Vuetify from 'vuetify'
 

--- a/test/unit/store/item-ranking.spec.js
+++ b/test/unit/store/item-ranking.spec.js
@@ -57,14 +57,14 @@ describe('item-ranking', () => {
     expect(commitMock.mock.calls[1][1]).toMatchObject(itemToRemove)
   })
 
-  describe('setRankedItems', () => {
+  describe('setAndLimitRankedItems', () => {
     const commitMock = jest.fn()
     const state = {
       ...getFreshState(),
       maxRankedItems: 2
     }
 
-    actions.setRankedItems(
+    actions.setAndLimitRankedItems(
       {
         commit: commitMock,
         state

--- a/test/unit/store/item-ranking.spec.js
+++ b/test/unit/store/item-ranking.spec.js
@@ -1,0 +1,83 @@
+import { actions, defaultState } from '@/store/item-ranking'
+
+const getFreshState = () => JSON.parse(JSON.stringify(defaultState))
+
+describe('item-ranking', () => {
+  describe('moveItemToRankedList', () => {
+    it('should not allow ranked list to exceed max', () => {
+      const commitMock = jest.fn()
+      const state = {
+        ...getFreshState(),
+        maxRankedItems: 2,
+        rankedItems: [{ id: 1 }, { id: 2 }],
+        unrankedItems: [{ id: 3 }, { id: 4 }]
+      }
+
+      actions.moveItemToRankedList(
+        {
+          commit: commitMock,
+          state
+        },
+        { id: 5 }
+      )
+
+      expect(commitMock).toHaveBeenCalledTimes(4)
+      expect(commitMock.mock.calls[0][0]).toBe('addUnrankedItem')
+      expect(commitMock.mock.calls[0][1]).toMatchObject({ id: 2 })
+      expect(commitMock.mock.calls[1][0]).toBe('removeRankedItem')
+      expect(commitMock.mock.calls[1][1]).toMatchObject({ id: 2 })
+      expect(commitMock.mock.calls[2][0]).toBe('addRankedItem')
+      expect(commitMock.mock.calls[2][1]).toMatchObject({ id: 5 })
+      expect(commitMock.mock.calls[3][0]).toBe('removeUnrankedItem')
+      expect(commitMock.mock.calls[3][1]).toMatchObject({ id: 5 })
+    })
+  })
+
+  describe('moveItemToUnrankedList', () => {
+    const commitMock = jest.fn()
+    const state = {
+      ...getFreshState(),
+      maxRankedItems: 2,
+      rankedItems: [{ id: 0 }, { id: 1 }]
+    }
+    const itemToRemove = state.rankedItems[0]
+
+    actions.moveItemToUnrankedList(
+      {
+        commit: commitMock,
+        state
+      },
+      itemToRemove
+    )
+
+    expect(commitMock.mock.calls).toHaveLength(2)
+    expect(commitMock.mock.calls[0][0]).toBe('addUnrankedItem')
+    expect(commitMock.mock.calls[0][1]).toMatchObject(itemToRemove)
+    expect(commitMock.mock.calls[1][0]).toBe('removeRankedItem')
+    expect(commitMock.mock.calls[1][1]).toMatchObject(itemToRemove)
+  })
+
+  describe('setRankedItems', () => {
+    const commitMock = jest.fn()
+    const state = {
+      ...getFreshState(),
+      maxRankedItems: 2
+    }
+
+    actions.setRankedItems(
+      {
+        commit: commitMock,
+        state
+      },
+      [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }]
+    )
+
+    expect(commitMock.mock.calls).toHaveLength(3)
+    expect(commitMock.mock.calls[0][0]).toBe('addUnrankedItem')
+    expect(commitMock.mock.calls[0][1]).toMatchObject({ id: 2 })
+    expect(commitMock.mock.calls[1][0]).toBe('addUnrankedItem')
+    expect(commitMock.mock.calls[1][1]).toMatchObject({ id: 3 })
+    expect(commitMock.mock.calls[2][0]).toBe('setRankedItems')
+    expect(commitMock.mock.calls[2][1]).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
# Goal of PR
Limit the number of items that can be added to the ranked items list.  If the user attempts to add additional items, the lowest-ranked item in the list is returned to the unranked list when the new item is added.

# TODO
 - [x] Add tests for new `store` actions.

@SharpNotions/ten-hour-project 