### PR TITLE
Support saving rankings from UI

### DIFF
--- a/src/api/list-mock.js
+++ b/src/api/list-mock.js
@@ -29,7 +29,7 @@ export default {
     localStorage.setItem('items', JSON.stringify(this.state.items))
     return resolveEventually(item)
   },
-  listItems() {
+  async listItems() {
     this.state.items = JSON.parse(localStorage.getItem('items') || '[]')
     this.state.rankedItemIds = loadRankedItemIds()
     this.state.idCount = this.state.items.length
@@ -40,7 +40,7 @@ export default {
       )
     )
   },
-  listRankedItems() {
+  async listRankedItems() {
     this.state.rankedItemIds = loadRankedItemIds()
     const actualItems = this.state.rankedItemIds.reduce((acc, id) => {
       const item = this.state.items.find(i => i.id === id)
@@ -66,7 +66,7 @@ export default {
 
     saveRankedItemIds(this.state.rankedItemIds)
   },
-  deleteItemRank(itemId) {
+  async deleteItemRank(itemId) {
     this.state.rankedItemIds = loadRankedItemIds()
     const itemIndex = this.state.rankedItemIds.indexOf(itemId)
     if (itemIndex !== -1) {

--- a/src/api/list-mock.js
+++ b/src/api/list-mock.js
@@ -27,7 +27,7 @@ export default {
     item.id = this.state.idCount++
     this.state.items.push(item)
     localStorage.setItem('items', JSON.stringify(this.state.items))
-    return resolveEventually(this.state.items)
+    return resolveEventually(item)
   },
   listItems() {
     this.state.items = JSON.parse(localStorage.getItem('items') || '[]')

--- a/src/api/list-mock.js
+++ b/src/api/list-mock.js
@@ -9,7 +9,7 @@ export default {
     loading: false,
     idCount: 0,
     items: [],
-    rankedItems: []
+    rankedItemIds: []
   },
   createItem(item = {}) {
     item = {
@@ -25,26 +25,45 @@ export default {
   },
   listItems() {
     this.state.items = JSON.parse(localStorage.getItem('items') || '[]')
-    this.state.rankedItems = JSON.parse(
-      localStorage.getItem('rankedItems') || '[]'
+    this.state.rankedItemIds = JSON.parse(
+      localStorage.getItem('rankedItemIds') || '[]'
     )
     this.state.idCount = this.state.items.length
     return resolveEventually(
       // Only return items that aren't in the user's ranked list.
       this.state.items.filter(
-        item => !this.state.rankedItems.some(ranked => item.id === ranked.id)
+        item => !this.state.rankedItemIds.some(rankedId => item.id === rankedId)
       )
     )
   },
   listRankedItems() {
-    this.state.rankedItems = JSON.parse(
-      localStorage.getItem('rankedItems') || '[]'
+    this.state.rankedItemIds = JSON.parse(
+      localStorage.getItem('rankedItemIds') || '[]'
     )
-    return resolveEventually(this.state.rankedItems)
+    return resolveEventually(this.state.rankedItemIds)
   },
-  saveRankedItems(rankedItems) {
-    this.state.rankedItems = rankedItems
-    localStorage.setItem('rankedItems', JSON.stringify(this.state.rankedItems))
-    return resolveEventually(rankedItems)
+  postItemRank(previousItemId, itemId) {
+    if (!previousItemId) {
+      this.state.rankedItemIds.push(itemId)
+    } else {
+      const previousItemIndex = this.state.rankedItemIds.indexOf(previousItemId)
+      const itemIndex = this.state.rankedItemIds.indexOf(itemId)
+      // Use bitwise operators to convert -1 to 0 if item not in array.
+      if (~previousItemIndex && !~itemIndex) {
+        this.state.rankedItemsIds.splice(previousItemIndex, 0, itemIndex)
+        // TODO: Limit to `n` items in ranked array.
+      } else {
+        return Promise.reject(new Error('Previous item or item ID not found'))
+      }
+    }
+  },
+  deleteItemRank(itemId) {
+    const itemIndex = this.state.rankedItemIds.indexOf(itemId)
+    // Use bitwise operators to convert -1 to 0 if item not in array.
+    if (!~itemIndex) {
+      this.state.rankedItemsIds.splice(itemIndex, 1)
+    } else {
+      return Promise.reject(new Error('Previous item or item ID not found'))
+    }
   }
 }

--- a/src/components/DraggableItemList.vue
+++ b/src/components/DraggableItemList.vue
@@ -12,6 +12,7 @@
     >
       <v-list-tile
         v-for="item in list" :key="item.item_name"
+        :data-item-id="item.id"
         @click="$emit('item-click', item)"
         class="list-item">
         <v-list-tile-content>

--- a/src/components/DraggableItemList.vue
+++ b/src/components/DraggableItemList.vue
@@ -40,11 +40,11 @@ export default {
   props: {
     items: {
       type: Array,
-      default: []
+      default: () => []
     },
     options: {
       type: Object,
-      default: {}
+      default: () => ({})
     }
   },
   computed: {

--- a/src/components/DraggableItemList.vue
+++ b/src/components/DraggableItemList.vue
@@ -1,6 +1,15 @@
 <template>
   <v-list two-line :class="{ empty: list.length === 0 }">
-    <draggable v-model="list" :options="options" class="draggable-list">
+    <draggable
+      v-model="list"
+      :options="options"
+      @end="bubbleEvent"
+      @add="bubbleEvent"
+      @update="bubbleEvent"
+      @sort="bubbleEvent"
+      @remove="bubbleEvent"
+      class="draggable-list"
+    >
       <v-list-tile
         v-for="item in list" :key="item.item_name"
         @click="$emit('item-click', item)"
@@ -50,6 +59,9 @@ export default {
   methods: {
     hasItemDetails(item) {
       return item.item_details && item.item_details.description
+    },
+    bubbleEvent(event) {
+      this.$emit(event.type, event)
     }
   }
 }

--- a/src/components/ItemRanking.vue
+++ b/src/components/ItemRanking.vue
@@ -37,7 +37,11 @@
               :options="{ group: 'ranking' }"
               @list-change="setAndLimitRankedItems"
               @info-click="showItemInfo"
-              @item-click="moveItemToUnrankedList">
+              @item-click="moveItemToUnrankedList"
+              @add="onRankedItemAdded"
+              @remove="onRankedItemRemoved"
+              @update="onRankedItemReorder"
+            >
             </draggable-item-list>
           </v-flex>
           <v-flex xs6>
@@ -117,6 +121,21 @@ export default {
     ...mapGetters('itemRanking', ['allItems'])
   },
   methods: {
+    onRankedItemReorder(event) {
+      this.saveItemRank(this.getItemId(event.item))
+    },
+    onRankedItemAdded(event) {
+      this.saveItemRank(this.getItemId(event.item))
+    },
+    onRankedItemRemoved(event) {
+      this.deleteItemRank(this.getItemId(event.item))
+    },
+    getItemId(listItemElement) {
+      return parseInt(
+        listItemElement.firstChild.attributes['data-item-id'].nodeValue,
+        10
+      )
+    },
     onItemSelect(value) {
       // v-select @change emits a DOM Event and then the selected value on mouse click
       // we only care about the selected value
@@ -136,7 +155,9 @@ export default {
       'createItem',
       'moveItemToRankedList',
       'moveItemToUnrankedList',
-      'setAndLimitRankedItems'
+      'setAndLimitRankedItems',
+      'saveItemRank',
+      'deleteItemRank'
     ]),
     ...mapMutations('itemRanking', [
       'setUnrankedItems',

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -140,13 +140,6 @@ export const actions = {
     }
     commit('setRankedItems', rankedItems)
   },
-  async saveItemRankByIndex({ commit, dispatch, state }, targetIndex) {
-    try {
-      await dispatch('saveItemRank', state.rankedItems[targetIndex].id)
-    } catch (err) {
-      commit('setError', err.message)
-    }
-  },
   async saveItemRank({ commit, state }, targetId) {
     try {
       await api.postItemRank(
@@ -157,9 +150,9 @@ export const actions = {
       commit('setError', err.message)
     }
   },
-  async deleteItemRank({ commit, state }, ids) {
+  async deleteItemRank({ commit, state }, targetId) {
     try {
-      await api.deleteItemRank(ids.target)
+      await api.deleteItemRank(targetId)
     } catch (err) {
       commit('setError', err.message)
     }

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -84,9 +84,11 @@ export const actions = {
       console.error(err)
     }
   },
-  async createItem({ commit }, payload) {
+  async createItem({ commit, dispatch }, payload) {
     try {
-      commit('addRankedItem', await api.createItem(payload))
+      const newItem = await api.createItem(payload)
+      commit('addRankedItem', newItem)
+      await dispatch('saveItemRank', newItem.id)
     } catch (err) {
       commit('setError', "Oh no, it didn't work")
       console.error(err)

--- a/src/store/item-ranking.js
+++ b/src/store/item-ranking.js
@@ -1,4 +1,4 @@
-import api from '@/api/list'
+import api from '@/api/list-mock'
 
 export const defaultState = {
   maxRankedItems: 10,
@@ -20,6 +20,13 @@ export const findItemIndex = function(items, itemToFind) {
   }
   return items.findIndex(item => item.item_name === itemToFind.item_name)
 }
+
+const getPreceedingItemId = (items = [], itemId) => {
+  const itemIndex = items.findIndex(i => i.id === itemId)
+  return itemIndex > 0 ? items[itemIndex - 1].id : null
+}
+
+export const getLastItem = items => items[items.length - 1]
 
 export const mutations = {
   setAllItems(state, items) {
@@ -71,7 +78,7 @@ export const actions = {
   async loadItems({ commit }) {
     try {
       commit('setUnrankedItems', await api.listItems())
-      commit('setRankedItems', [])
+      commit('setRankedItems', await api.listRankedItems())
     } catch (err) {
       commit('setError', 'Something broke')
       console.error(err)
@@ -85,28 +92,40 @@ export const actions = {
       console.error(err)
     }
   },
-  moveItemToRankedList({ commit, state }, item) {
+  async moveItemToRankedList({ commit, dispatch, state }, item) {
     try {
       if (state.rankedItems.length >= state.maxRankedItems) {
-        commit(
-          'addUnrankedItem',
-          state.rankedItems[state.rankedItems.length - 1]
+        const itemToMove = getLastItem(state.rankedItems)
+        const preceedingItemId = getPreceedingItemId(
+          state.rankedItems,
+          itemToMove
         )
-        commit(
-          'removeRankedItem',
-          state.rankedItems[state.rankedItems.length - 1]
-        )
+        commit('addUnrankedItem', itemToMove)
+        commit('removeRankedItem', itemToMove)
+
+        // Save changes to server.
+        // TODO: Recover if save fails.
+        await dispatch('deleteItemRank', preceedingItemId, itemToMove.id)
       }
       commit('addRankedItem', item)
       commit('removeUnrankedItem', item)
+
+      // Save changes to server.
+      // TODO: Recover if save fails.
+      await dispatch('saveItemRank', item.id)
     } catch (err) {
       commit('setError', err.message)
     }
   },
-  moveItemToUnrankedList({ commit }, item) {
+  async moveItemToUnrankedList({ commit, dispatch, state }, item) {
     try {
       commit('addUnrankedItem', item)
       commit('removeRankedItem', item)
+
+      await dispatch('deleteItemRank', {
+        preceeding: getPreceedingItemId(state.rankedItems, item),
+        target: item.id
+      })
     } catch (err) {
       commit('setError', err.message)
     }
@@ -120,6 +139,30 @@ export const actions = {
       rankedItems = rankedItems.slice(0, state.maxRankedItems)
     }
     commit('setRankedItems', rankedItems)
+  },
+  async saveItemRankByIndex({ commit, dispatch, state }, targetIndex) {
+    try {
+      await dispatch('saveItemRank', state.rankedItems[targetIndex].id)
+    } catch (err) {
+      commit('setError', err.message)
+    }
+  },
+  async saveItemRank({ commit, state }, targetId) {
+    try {
+      await api.postItemRank(
+        getPreceedingItemId(state.rankedItems, targetId),
+        targetId
+      )
+    } catch (err) {
+      commit('setError', err.message)
+    }
+  },
+  async deleteItemRank({ commit, state }, ids) {
+    try {
+      await api.deleteItemRank(ids.target)
+    } catch (err) {
+      commit('setError', err.message)
+    }
   }
 }
 

--- a/test/unit/store/item-ranking.spec.js
+++ b/test/unit/store/item-ranking.spec.js
@@ -2,9 +2,11 @@ import { actions, defaultState } from '@/store/item-ranking'
 
 const getFreshState = () => JSON.parse(JSON.stringify(defaultState))
 
+const resolveWith = payload => Promise.resolve()
+
 describe('item-ranking', () => {
   describe('moveItemToRankedList', () => {
-    it('should not allow ranked list to exceed max', () => {
+    it('should not allow ranked list to exceed max', async () => {
       const commitMock = jest.fn()
       const state = {
         ...getFreshState(),
@@ -13,9 +15,10 @@ describe('item-ranking', () => {
         unrankedItems: [{ id: 3 }, { id: 4 }]
       }
 
-      actions.moveItemToRankedList(
+      await actions.moveItemToRankedList(
         {
           commit: commitMock,
+          dispatch: resolveWith,
           state
         },
         { id: 5 }
@@ -33,7 +36,7 @@ describe('item-ranking', () => {
     })
   })
 
-  describe('moveItemToUnrankedList', () => {
+  describe('moveItemToUnrankedList', async () => {
     const commitMock = jest.fn()
     const state = {
       ...getFreshState(),
@@ -42,9 +45,10 @@ describe('item-ranking', () => {
     }
     const itemToRemove = state.rankedItems[0]
 
-    actions.moveItemToUnrankedList(
+    await actions.moveItemToUnrankedList(
       {
         commit: commitMock,
+        dispatch: resolveWith,
         state
       },
       itemToRemove
@@ -67,6 +71,7 @@ describe('item-ranking', () => {
     actions.setAndLimitRankedItems(
       {
         commit: commitMock,
+        dispatch: resolveWith,
         state
       },
       [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }]


### PR DESCRIPTION
# Goal of PR
Allow the UI to save rankings when items are added, removed and re-ordered in the `ranked items` list.

# TODO
 - [x] Update mock API to support saving rankings
 - [x] Save rankings on re-order
 - [x] Save rankings on dragging items to/from `ranked items` list
 - [x] Fix existing tests

**Please Review:** @SharpNotions/ten-hour-project 