### PR TITLE
feat: Hook up DELETE endpoint in API.

### DIFF
--- a/src/api/list.js
+++ b/src/api/list.js
@@ -41,7 +41,16 @@ export default {
       })
     }).then(response => response.json())
   },
-  deleteItemRank() {
-    return Promise.resolve()
+  deleteItemRank(targetItemId) {
+    return fetch('/api/user_ranking', {
+      method: 'DELETE',
+      headers: {
+        'content-type': 'application/json'
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        item_id: targetItemId
+      })
+    })
   }
 }


### PR DESCRIPTION
Sends deletion requests to the API for user rankings.

**NOTE:**  There is currently a UNIQUE constraint on the `UserRankings.prev_ranking_id` that prevents items from being ranked after they have been un-ranked.  This is due to the fact that we're currently soft-deleting records in the table.  The easiest solution is to switch back over to hard deletes but I'm open to other suggestions.

@SharpNotions/ten-hour-project 