### PR TITLE
Allow Docker Deploys to Heroku

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,7 +13,10 @@ RUN npm install && npm run build
 # NGINX image
 FROM nginx:latest
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html/dist
-COPY default.conf /etc/nginx/conf.d/
+COPY default.template /etc/nginx/conf.d/
 COPY index.html /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+COPY docker-entrypoint.sh /
+RUN chmod u+x /docker-entrypoint.sh
+# EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["sh", "-c"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -17,6 +17,6 @@ COPY default.template /etc/nginx/conf.d/
 COPY index.html /usr/share/nginx/html
 COPY docker-entrypoint.sh /
 RUN chmod u+x /docker-entrypoint.sh
-# EXPOSE 80
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["sh", "-c"]

--- a/default.template
+++ b/default.template
@@ -1,4 +1,5 @@
 server {
+  listen ${PORT};
   root /usr/share/nginx/html;
 
   location / {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
 sed "s/\${PORT}/$PORT/" /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
 cat /etc/nginx/conf.d/default.conf
 nginx -g 'daemon off;'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 sed "s/\${PORT}/$PORT/" /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
-cat /etc/nginx/conf.d/default.conf
 nginx -g 'daemon off;'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
+sed "s/\${PORT}/$PORT/" /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
+cat /etc/nginx/conf.d/default.conf
+nginx -g 'daemon off;'

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile.build
+  config:
+    NODE_ENV: production


### PR DESCRIPTION
# Goal of PR
- Heroku assigns a random port to the deployed container.  In order to accommodate this, we have to use `sed` to update the `nginx` config's `listen` parameter to point to the `$PORT` environment variable.
- Heroku requires build specifications to be defined in a `heroku.yml` file.

**Note:** This migration to Heroku doesn't include running tests.  We could enable a test step on Heroku but it will cost an additional $10 per month.  We don't currently have many tests on the front-end so I'm included to let this go for the moment.  If we want to enable tests later, we might consider pulling CircleCI into our process.

@SharpNotions/ten-hour-project 